### PR TITLE
Add clientShift routes with shift processing logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.9.0",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -556,6 +557,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -743,6 +761,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -835,6 +865,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -908,6 +947,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1294,6 +1348,63 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1426,6 +1537,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2034,6 +2160,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "axios": "^1.9.0",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8181";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import clientShiftRouter from "./routes/clientShift";
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -8,6 +9,7 @@ app.use(express.json());
 app.get("/", (_req, res) => {
   res.send("Hello World!");
 });
+app.use("/client-shift", clientShiftRouter);
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);

--- a/src/routes/clientShift.ts
+++ b/src/routes/clientShift.ts
@@ -1,0 +1,39 @@
+import { Router, Request } from "express";
+import { processShifts, Shift } from "../services/shiftService";
+import { API_BASE_URL } from "../config";
+
+import axios from "axios";
+
+const router = Router();
+
+router.post("/", async (_req: Request<{}, {}, Shift[]>, res: any) => {
+  const shifts = _req.body;
+
+  if (!Array.isArray(shifts)) {
+    return res.status(400).json({ error: "You must send an array of shifts" });
+  }
+
+  try {
+    const result = await processShifts(shifts);
+    res.status(200).json({ message: "All shifts processed", result });
+  } catch (error) {
+    res.status(500).json({
+      error: "Failed to process some shifts, check the list before retry",
+      details: error,
+    });
+  }
+});
+
+router.get("/", async (_req, res) => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/shifts`);
+    res.status(200).json(response.data);
+  } catch (error: any) {
+    res.status(502).json({
+      error: "Failed to fetch shifts from external API",
+      details: error.message,
+    });
+  }
+});
+
+export default router;

--- a/src/services/shiftService.ts
+++ b/src/services/shiftService.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+import { retry } from "../utils/retry";
+import { API_BASE_URL } from "../config";
+
+export interface Shift {
+  companyId: string;
+  userId: string;
+  startTime: string;
+  endTime: string;
+  action: string;
+}
+
+function getShiftKey(shift: Shift): string {
+  return `${shift.companyId}-${shift.userId}-${shift.startTime}-${shift.endTime}`;
+}
+
+export async function processShifts(shifts: Shift[]) {
+  const results = [];
+
+  for (const shift of shifts) {
+    const key = getShiftKey(shift);
+
+    try {
+      const response = await retry(() =>
+        axios.post(`${API_BASE_URL}/shift`, shift, {
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+      results.push({ shift, data: response.data });
+    } catch (error) {
+      console.error(`Failed to process shift ${key}`);
+    }
+  }
+
+  return results;
+}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,22 @@
+export async function retry<T>(
+  fn: () => Promise<T>,
+  retries = 15,
+  delay = 500
+): Promise<T> {
+  let attempt = 0;
+
+  while (attempt < retries) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      if (err.response?.status === 500) {
+        attempt++;
+        await new Promise((res) => setTimeout(res, delay));
+      } else {
+        throw err; // don't retry non-500s
+      }
+    }
+  }
+
+  throw new Error(`Failed after ${retries} retries`);
+}


### PR DESCRIPTION
##  Summary

This PR adds core functionality for shift booking and retrieval via a Node.js + TypeScript API.

### Changes
 - Added `axios` as a dependency in package.json and package-lock.json.
 - Created` config.ts` for API base URL configuration.
 - Implemented `clientShift` router with `POST` and `GET` endpoints for shift processing.
 - Added `shiftService` for processing shifts and retry logic.
 - Introduced `retry` utility for handling API request retries.

###  Features

- `POST /client-shift`: Accepts an array of  shifts and processes them via a 3rd-party API.
  - Includes retry logic for unreliable upstream (50%+ failure rate).
- `GET /client-shift`: Retrieves all shifts from the external shift booking API.

###  Retry Logic

The `processShifts` function retries each shift up to **15 times** to ensure a high success rate (~99.5%) given the simulated 70% failure probability in the external API.

### 🧪 How to Test

Make sure Docker container is running:

```bash
docker run -p 8181:8080 igorsakhankov/harbour-cloudcomputing
